### PR TITLE
Update activerecord-collection_cache_key to send :include for Rails 3.2.22.1

### DIFF
--- a/lib/activerecord-collection_cache_key.rb
+++ b/lib/activerecord-collection_cache_key.rb
@@ -5,4 +5,4 @@ require 'collection_cache_key/relation'
 require 'collection_cache_key/version'
 
 ActiveRecord::Base.extend CollectionCacheKey::CacheKey
-ActiveRecord::Relation.include CollectionCacheKey::Relation
+ActiveRecord::Relation.send(:include, CollectionCacheKey::Relation)


### PR DESCRIPTION
Resolves load errors on in ActiveRecord::Relation due to activerecord-collection_cache_key.rb:8 calling a private method.

Resolves #4 